### PR TITLE
turn off live asset compiling in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,11 +30,7 @@ Rails.application.configure do
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  #config.assets.compile = false
-  # feel free to change it back to false, but it had to be true to make glyphs work in my case.
-  # I am not really sure why that is at the moment
-  config.assets.compile = true
+  config.assets.compile = false
 
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,


### PR DESCRIPTION
live asset compiling in prod might be undesirable by default. I checked glyph icons work fine, we just have to run 
`bundle exec rake assets:precompile`
 before running in prod